### PR TITLE
Downgraded liftjson to 2.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,24 +14,22 @@ Newman supports the following basic features:
 * In memory response caching with TTL expiry
 * ETag HTTP caching
 
-To add it to your project, use this for Maven:
+## Usage for scala 2.11
 
-```xml
-<dependency>
-  <groupId>com.stackmob</groupId>
-  <artifactId>newman_${scala.version}</artifactId>
-  <version>1.3.5</version>
-</dependency>
-```
-
-or the equivalent for sbt:
+### sbt
 
 ```scala
-libraryDependencies += "com.stackmob" %% "newman" % "1.3.5"
+	resolvers ++= Seq(Resolver.sonatypeRepo("releases"),
+	Resolver.sonatypeRepo("snapshots"),
+	Resolver.bintrayRepo("scalaz", "releases"),
+	Resolver.bintrayRepo("io.megam", "scala"))
+
+	libraryDependencies += "io.megam" % "newman" % "1.3.9"
+
 ```
 
 # Basic Usage
-	
+
 ```scala
 import com.stackmob.newman._
 import com.stackmob.newman.dsl._
@@ -47,13 +45,13 @@ println(s"Response returned from ${url.toString} with code ${response.code}, bod
 ```
 
 #The DSL
-Newman comes with a DSL which is inspired by [Dispatch](http://dispatch.databinder.net/Dispatch.html), 
+Newman comes with a DSL which is inspired by [Dispatch](http://dispatch.databinder.net/Dispatch.html),
 but uses mostly english instead of symbols.
-This DSL is the recommended way to build requests, and the above example in "Basic Usage" uses the DSL to 
+This DSL is the recommended way to build requests, and the above example in "Basic Usage" uses the DSL to
 construct a GET request.
 
-To start using the DSL, simply `import com.stackmob.newman.dsl._`. 
-The functions of interest in the DSL are uppercase representations of the HTTP verbs: 
+To start using the DSL, simply `import com.stackmob.newman.dsl._`.
+The functions of interest in the DSL are uppercase representations of the HTTP verbs:
 
 * `def GET(url: URL)(implicit client: HttpClient)`
 * `def POST(url: URL)(implicit client: HttpClient)`
@@ -61,10 +59,10 @@ The functions of interest in the DSL are uppercase representations of the HTTP v
 * `def DELETE(url: URL)(implicit client: HttpClient)`
 * `def HEAD(url: URL)(implicit client: HttpClient)`
 
-Notice that each method takes an implicit `HttpClient`, so you must declare your own implicit before 
+Notice that each method takes an implicit `HttpClient`, so you must declare your own implicit before
 you use any of the above listed DSL methods, or pass one explicitly.
 
-Each method listed above returns a Builder, which works in concert with the implicit methods defined 
+Each method listed above returns a Builder, which works in concert with the implicit methods defined
 in the `DSL` package to let you build up a request and then execute it.
 
 # Executing Requests
@@ -95,13 +93,13 @@ import com.stackmob.newman.{ETagAwareHttpClient, ApacheHttpClient}
 import com.stackmob.newman.caching.InMemoryHttpResponseCacher
 import com.stackmob.newman.dsl._
 import java.net.URL
-	
+
 //change this implementation to your own if you want to use Memcached, Redis, etc
 val cache = new InMemoryHttpResponseCacher
 val rawHttpClient = new ApacheHttpClient
 //eTagClient will be used in the DSL to construct & execute requests below
 implicit val eTagClient = new ETagAwareHttpClient(rawHttpClient, cache)
-	
+
 val url = new URL("http://stackmob.com")
 //since the cacher is empty, this will issue a request to stackmob.com without an If-None-Match header
 val res1 = GET(url).apply

--- a/build.sbt
+++ b/build.sbt
@@ -48,10 +48,9 @@ libraryDependencies ++= {
   val httpClientVersion = "4.4.1"
   val scalaCheckVersion = "1.12.2"
   val specs2Version = "3.6"
-  val mockitoVersion = "1.9.0"
-  val liftJsonVersion = "3.0-M5-1"
+  val liftJsonVersion = "2.6.2"
   val sprayVersion = "1.3.3"
-  val akkaVersion = "2.3.10"
+  val akkaVersion = "2.3.11"
 
 
   Seq(
@@ -66,7 +65,6 @@ libraryDependencies ++= {
     "net.liftweb" %% "lift-json-scalaz7" % liftJsonVersion,
     "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
     "org.specs2" %% "specs2-core" % specs2Version % "test" exclude("org.scalaz", "scalaz-core_2.11"),
-    "org.pegdown" % "pegdown" % "1.5.0" % "test" exclude("org.parboiled", "parboiled-core"),
-    "org.mockito" % "mockito-all" % mockitoVersion % "test"
+    "org.mockito" % "mockito-all" % "1.10.19" % "test"
   )
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.8"
+version in ThisBuild := "1.3.9"


### PR DESCRIPTION
found few issues in liftjson. I am not sure this is tied to the version. Downgrading to 2.6.2 has the same issues as well. 

It might be a scala 2.11/scalaz issue. But i am leaving the `liftweb-json-scalaz` to the latest stable `2.6.2`
